### PR TITLE
PLATUI-629: Update to SBT 1.3.13 and Scala 2.12.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,12 @@
-import sbt.Keys._
-import sbt._
-import sbt.plugins.{CorePlugin, IvyPlugin, JvmPlugin}
-
-val appName = "tracking-consent-frontend-performance-tests"
-val appVersion = "0.1.0-SNAPSHOT"
-
-lazy val microservice = Project(appName, file("."))
+lazy val root = (project in file("."))
   .enablePlugins(GatlingPlugin)
   .enablePlugins(CorePlugin)
   .enablePlugins(JvmPlugin)
   .enablePlugins(IvyPlugin)
   .settings(
-    version := appVersion,
-    scalaVersion := "2.11.12",
+    name := "tracking-consent-frontend-performance-tests",
+    version := "0.1.0-SNAPSHOT",
+    scalaVersion := "2.12.12",
     libraryDependencies ++= Seq(
       Dependencies.Compile.typesafeConfig,
       Dependencies.Compile.gatlingHighCharts,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,11 +2,11 @@ import sbt._
 
 object Dependencies {
 
-  private val gatlingVersion = "2.2.5"
+  private val gatlingVersion = "2.3.1"
 
   object Compile {
     val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
-    val performanceTestRunner = "uk.gov.hmrc" %% "performance-test-runner" % "3.1.0"
+    val performanceTestRunner = "uk.gov.hmrc" %% "performance-test-runner" % "3.7.0"
     val gatlingTestFramework = "io.gatling" % "gatling-test-framework" % gatlingVersion
     val gatlingHighCharts = "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.co
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
 
-addSbtPlugin("io.gatling" % "gatling-sbt" % "2.2.0")
+addSbtPlugin("io.gatling" % "gatling-sbt" % "2.2.2")


### PR DESCRIPTION
Updated to use build.sbt to support SBT 1.x.x
Updated performance-test-runner, gatling-charts, gatling-test-framework and plugins to support Scala 2.12 and SBT 1.x.x