### PR TITLE
PLATUI-629

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,15 @@ lazy val root = (project in file("."))
     version := "0.1.0-SNAPSHOT",
     scalaVersion := "2.12.12",
     libraryDependencies ++= Dependencies.test,
-    scalacOptions ++= Seq("-feature"),
+    scalacOptions ++= Seq(
+      "-unchecked",
+      "-deprecation",
+      "-Xlint",
+      "-target:jvm-1.8",
+      "-Xmax-classfile-name", "100",
+      "-encoding", "UTF-8",
+      "-feature"
+    ),
     javaOptions in Gatling ++= overrideDefaultJavaOptions("-Xms4096m", "-Xmx16384m"),
     retrieveManaged := true,
     initialCommands in console := "import uk.gov.hmrc._",

--- a/build.sbt
+++ b/build.sbt
@@ -3,25 +3,19 @@ lazy val root = (project in file("."))
   .enablePlugins(CorePlugin)
   .enablePlugins(JvmPlugin)
   .enablePlugins(IvyPlugin)
+  .enablePlugins(SbtAutoBuildPlugin)
   .settings(
     name := "tracking-consent-frontend-performance-tests",
     version := "0.1.0-SNAPSHOT",
     scalaVersion := "2.12.12",
     libraryDependencies ++= Dependencies.test,
-    scalacOptions ++= Seq(
-      "-unchecked",
-      "-deprecation",
-      "-Xlint",
-      "-target:jvm-1.8",
-      "-Xmax-classfile-name", "100",
-      "-encoding", "UTF-8",
-      "-feature"
-    ),
+    scalacOptions ++= Seq("-feature"),
     javaOptions in Gatling ++= overrideDefaultJavaOptions("-Xms4096m", "-Xmx16384m"),
     retrieveManaged := true,
     initialCommands in console := "import uk.gov.hmrc._",
     parallelExecution in Test := false,
     publishArtifact in Test := true,
+    testOptions in Test := Seq.empty,
     resolvers ++= Seq(
       Resolver.bintrayRepo("hmrc", "releases"),
       Resolver.typesafeRepo("releases")

--- a/build.sbt
+++ b/build.sbt
@@ -7,21 +7,8 @@ lazy val root = (project in file("."))
     name := "tracking-consent-frontend-performance-tests",
     version := "0.1.0-SNAPSHOT",
     scalaVersion := "2.12.12",
-    libraryDependencies ++= Seq(
-      Dependencies.Compile.typesafeConfig,
-      Dependencies.Compile.gatlingHighCharts,
-      Dependencies.Compile.gatlingTestFramework,
-      Dependencies.Compile.performanceTestRunner
-    ),
-    scalacOptions ++= Seq(
-      "-unchecked",
-      "-deprecation",
-      "-Xlint",
-      "-language:_",
-      "-target:jvm-1.8",
-      "-Xmax-classfile-name", "100",
-      "-encoding", "UTF-8"
-    ),
+    libraryDependencies ++= Dependencies.test,
+    scalacOptions ++= Seq("-feature"),
     javaOptions in Gatling ++= overrideDefaultJavaOptions("-Xms4096m", "-Xmx16384m"),
     retrieveManaged := true,
     initialCommands in console := "import uk.gov.hmrc._",

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ lazy val root = (project in file("."))
     initialCommands in console := "import uk.gov.hmrc._",
     parallelExecution in Test := false,
     publishArtifact in Test := true,
+    // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.
+    // These testOptions are not compatible with `sbt gatling:test`. So we have to override testOptions here.
     testOptions in Test := Seq.empty,
     resolvers ++= Seq(
       Resolver.bintrayRepo("hmrc", "releases"),

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,14 @@
 lazy val root = (project in file("."))
   .enablePlugins(GatlingPlugin)
-  .enablePlugins(CorePlugin)
-  .enablePlugins(JvmPlugin)
-  .enablePlugins(IvyPlugin)
   .enablePlugins(SbtAutoBuildPlugin)
   .settings(
     name := "tracking-consent-frontend-performance-tests",
     version := "0.1.0-SNAPSHOT",
     scalaVersion := "2.12.12",
     libraryDependencies ++= Dependencies.test,
-    scalacOptions ++= Seq("-feature"),
+    //implicitConversions & postfixOps are Gatling recommended -language settings
+    scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
     javaOptions in Gatling ++= overrideDefaultJavaOptions("-Xms4096m", "-Xmx16384m"),
-    retrieveManaged := true,
-    initialCommands in console := "import uk.gov.hmrc._",
-    parallelExecution in Test := false,
-    publishArtifact in Test := true,
     // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.
     // These testOptions are not compatible with `sbt gatling:test`. So we have to override testOptions here.
     testOptions in Test := Seq.empty,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,11 +4,11 @@ object Dependencies {
 
   private val gatlingVersion = "2.3.1"
 
-  object Compile {
-    val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
-    val performanceTestRunner = "uk.gov.hmrc" %% "performance-test-runner" % "3.7.0"
-    val gatlingTestFramework = "io.gatling" % "gatling-test-framework" % gatlingVersion
-    val gatlingHighCharts = "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion
-  }
+  val test = Seq(
+    "com.typesafe"          % "config"                    % "1.3.1"        % Test,
+    "uk.gov.hmrc"           %% "performance-test-runner"  % "3.7.0"        % Test,
+    "io.gatling"            % "gatling-test-framework"    % gatlingVersion % Test,
+    "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion % Test
+  )
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,9 +5,9 @@ object Dependencies {
   private val gatlingVersion = "2.3.1"
 
   val test = Seq(
-    "com.typesafe"          % "config"                    % "1.3.1"        % Test,
-    "uk.gov.hmrc"           %% "performance-test-runner"  % "3.7.0"        % Test,
-    "io.gatling"            % "gatling-test-framework"    % gatlingVersion % Test,
+    "com.typesafe" % "config" % "1.3.1" % Test,
+    "uk.gov.hmrc" %% "performance-test-runner" % "3.7.0" % Test,
+    "io.gatling" % "gatling-test-framework" % gatlingVersion % Test,
     "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion % Test
   )
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,3 +1,16 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # The default url for every service.
 # For example

--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -1,6 +1,16 @@
-#########################
-# Gatling Configuration #
-#########################
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This file contains all the settings configurable for Gatling with their default values
 

--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#########################
+# Gatling Configuration #
+#########################
+
 # This file contains all the settings configurable for Gatling with their default values
 
 gatling {

--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Configure here your journeys. A journey is a sequence of requests at a certain load.
+
 journeys {
 
   # Example

--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -1,4 +1,16 @@
-# Configure here your journeys. A journey is a sequence of requests at a certain load.
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 journeys {
 

--- a/src/test/resources/services-local.conf
+++ b/src/test/resources/services-local.conf
@@ -1,3 +1,16 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This file is read when runLocal = true in application.conf (default)
 

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -1,3 +1,16 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This file is read when runLocal = false in application.conf (default is false)
 

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -7,10 +7,4 @@
 # For local development convenience, host and protocol will have the following defaults:
 #      protocol = http
 #      port = 8080
-services {
-  tracking-consent-frontend {
-    protocol = https
-    host = tracking-consent-frontend.public.mdtp
-    port = 443
-  }
-}
+#

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -7,4 +7,10 @@
 # For local development convenience, host and protocol will have the following defaults:
 #      protocol = http
 #      port = 8080
-#
+services {
+  tracking-consent-frontend {
+    protocol = https
+    host = tracking-consent-frontend.public.mdtp
+    port = 443
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.perftests.example
 
 import uk.gov.hmrc.performance.conf.ServicesConfiguration

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendSimulation.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendSimulation.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.perftests.example
 
 import uk.gov.hmrc.performance.simulation.PerformanceTestRunner


### PR DESCRIPTION
Enabled `SbtAutoBuildPlugin`. This brings in required Scala compiler settings. This also generates copyright headers. 
`SbtAutoBuildPlugin` provides `testOptions in Test` which is not compatible with `sbt gatling:test`. Hence requires overriding. 
Removed scalac `-language` settings as this was using a wildcard option. 
Introduced `-feature` flag to surface detailed warning messages when using advanced Scala language features without relevant settings/imports.
Added Gatling specific Scala Compiler language settings.
Marked all dependencies as Test and refactored them into a Seq.
`CorePlugin, JvmPlugin, IvyPlugin` are auto-enabled. So they do not need to be explicitly enabled.

**Removed the below settings:**
`retrieveManaged := true` // required only when a project specific local ivy_cache is required.
`initialCommands in console := "import uk.gov.hmrc._"` // required only when sbt console requires to be launched with this initial command.
`parallelExecution in Test := false` // provided by `SbtAutoBuild` plugin
`publishArtifact in Test := true` // not required unless a jar file for test classes and resources needs publishing.