### PR TITLE
PLATUI-2691: Update load for journey tests

### DIFF
--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -17,12 +17,12 @@
 journeys {
 
     get-tracking-js = {
-      description = "A service requests the tracking.js script"
+      description = "Browser requests the tracking.js script"
 
       # The load is in journeys per second. Put here the load you are going to have at the peak.
       # There is no need to put a higher value at this point. Use prerftest.loadPercentage in application.conf instead
-      # ~10% of calls return 200 OK with content
-      load = 25
+      # 100% of calls return 200 OK with content
+      load = 4
 
       # The parts your journey is made of. A part is made one or more requests.
       parts = [
@@ -30,27 +30,13 @@ journeys {
       ]
     }
 
-    get-tracking-js-cached = {
-      description = "A service requests the tracking.js script, but can use its cached copy"
-
-      # The load is in journeys per second. Put here the load you are going to have at the peak.
-      # There is no need to put a higher value at this point. Use prerftest.loadPercentage in application.conf instead
-      # ~90% of calls return 304 Not Modified with no body
-      load = 227
-
-      # The parts your journey is made of. A part is made one or more requests.
-      parts = [
-        tracking-js-cached
-      ]
-    }
-
     get-optimizely-js = {
-      description = "A service requests the optimizely.js script"
+      description = "Browser requests the optimizely.js script"
 
       # The load is in journeys per second. Put here the load you are going to have at the peak.
-      # There is no need to put a higher value at this point. Use prerftest.loadPercentage in application.conf instead
-      # ~10% of calls return 200 OK with content
-      load = 33
+      # There is no need to put a higher value at this point. Use perftest.loadPercentage in application.conf instead
+      # 100% of calls return 200 OK with content
+      load = 810
 
       # The parts your journey is made of. A part is made one or more requests.
       parts = [
@@ -58,26 +44,12 @@ journeys {
       ]
     }
 
-    get-optimizely-js-cached = {
-      description = "A service requests the optimizely.js script, but can use its cached copy"
-
-      # The load is in journeys per second. Put here the load you are going to have at the peak.
-      # There is no need to put a higher value at this point. Use prerftest.loadPercentage in application.conf instead
-      # ~90% of calls return 304 Not Modified with no body
-      load = 303
-
-      # The parts your journey is made of. A part is made one or more requests.
-      parts = [
-        optimizely-js-cached
-      ]
-    }
-
     audit-consent = {
       description = "A user's tracking consent decision is audited"
 
       # The load is in journeys per second. Put here the load you are going to have at the peak.
-      # There is no need to put a higher value at this point. Use prerftest.loadPercentage in application.conf instead
-      load = 12
+      # There is no need to put a higher value at this point. Use perftest.loadPercentage in application.conf instead
+      load = 20
 
       # The parts your journey is made of. A part is made one or more requests.
       parts = [
@@ -89,8 +61,8 @@ journeys {
       description = "A user visits the cookie settings page"
 
       # The load is in journeys per second. Put here the load you are going to have at the peak.
-      # There is no need to put a higher value at this point. Use prerftest.loadPercentage in application.conf instead
-      load = 0.06
+      # There is no need to put a higher value at this point. Use perftest.loadPercentage in application.conf instead
+      load = 0.11
 
       # The parts your journey is made of. A part is made one or more requests.
       parts = [

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
@@ -28,34 +28,16 @@ object TrackingConsentFrontendRequests extends ServicesConfiguration {
 
   private val baseUrl = baseUrlFor("tracking-consent-frontend")
 
-  private val httpCurrentDateTimeWithLeadingZero = DateTimeFormatter.RFC_1123_DATE_TIME
-    .format(ZonedDateTime.now(ZoneOffset.UTC))
-    .replaceFirst(", ([^0] )", ", 0$1")
-
   val getTrackingJs: HttpRequestBuilder = {
     http("GET tracking.js")
       .get(s"$baseUrl/tracking-consent/tracking.js")
       .check(status.is(200))
   }
 
-  val getTrackingJsNotModified: HttpRequestBuilder = {
-    http("GET tracking.js, but not modified")
-      .get(s"$baseUrl/tracking-consent/tracking.js")
-      .header(HttpHeaderNames.IfModifiedSince, httpCurrentDateTimeWithLeadingZero)
-      .check(status.is(304))
-  }
-
   val getOptimizelyJs: HttpRequestBuilder = {
     http("GET optimizely.js")
       .get(s"$baseUrl/tracking-consent/tracking/optimizely.js")
       .check(status.is(200))
-  }
-
-  val getOptimizelyJsNotModified: HttpRequestBuilder = {
-    http("GET optimizely.js, but not modified")
-      .get(s"$baseUrl/tracking-consent/tracking/optimizely.js")
-      .header(HttpHeaderNames.IfModifiedSince, httpCurrentDateTimeWithLeadingZero)
-      .check(status.is(304))
   }
 
   val getCookieSettingsPage: HttpRequestBuilder = {

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendSimulation.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendSimulation.scala
@@ -22,9 +22,7 @@ import uk.gov.hmrc.perftests.example.TrackingConsentFrontendRequests._
 class TrackingConsentFrontendSimulation extends PerformanceTestRunner {
 
   setup("tracking-js-uncached", "Request tracking.js, return 200 OK") withRequests getTrackingJs
-  setup("tracking-js-cached", "Request tracking.js, return 304 Not Modified") withRequests getTrackingJsNotModified
   setup("optimizely-js-uncached", "Request optimizely.js, return 200 OK") withRequests getOptimizelyJs
-  setup("optimizely-js-cached", "Request optimizely.js, return 304 Not Modified") withRequests getOptimizelyJsNotModified
   setup("audit-consent", "Audit the tracking consent decision") withRequests postToAuditEndpoint
   setup("cookie-settings", "Visit the cookie settings page") withRequests getCookieSettingsPage
 


### PR DESCRIPTION
Removed cached steps in Gatling config as they do not apply anymore, as caching is controlled by cloud front.