### PR TITLE
PLATUI-2764 scrape hmrc-frontend version from staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # tracking-consent-frontend-performance-tests
 
-Template of a performance test repository, using [performance-test-runner](https://github.com/hmrc/performance-test-runner) under the hood
-    
+Performance test repository for tracking-consent-frontend, using [performance-test-runner](https://github.com/hmrc/performance-test-runner) under the hood
+
+The `TrackingConsentFrontendRequests` tests will automatically try to find the version of hmrc-frontend in staging. To do this, it looks at https://www.staging.tax.service.gov.uk/help/cookie-details and scrapes the version of `hmrc-frontend-{version}.min.js`. Should staging go down or you're unable to reach this, it will default to the defaultHmrcFrontendVersion.
+
+```
+  private val defaultHmrcFrontendVersion = "5.66.0"
+```
+
 ### Smoke test
 
 It might be useful to try the journey with one user to check that everything works fine before running the full performance test

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/services-local.conf
+++ b/src/test/resources/services-local.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
@@ -40,7 +40,7 @@ object TrackingConsentFrontendRequests extends ServicesConfiguration {
       .check(status.is(200))
   }
 
-  val getLiveHmrcFrontendVersion: String = {
+  val currentHmrcFrontendVersion: String = {
     val url = "https://staging.tax.service.gov.uk/help/cookie-details"
     val versionRegex: Regex = raw"hmrc-frontend-([0-9]+\.[0-9]+\.[0-9]+)\.min.js".r
     val content: String = Source.fromURL(url).mkString
@@ -53,7 +53,7 @@ object TrackingConsentFrontendRequests extends ServicesConfiguration {
   }
 
   val getCookieSettingsPage: HttpRequestBuilder = {
-    val hmrcFrontendVersion = getLiveHmrcFrontendVersion
+    val hmrcFrontendVersion = currentHmrcFrontendVersion
     http("Load cookie settings page, with assets")
       .get(s"$baseUrl/tracking-consent/cookie-settings?enableTrackingConsent=true")
       .resources(

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
@@ -40,10 +40,9 @@ object TrackingConsentFrontendRequests extends ServicesConfiguration {
       .check(status.is(200))
   }
 
-  val currentHmrcFrontendVersion: String = {
-    val url = "https://staging.tax.service.gov.uk/help/cookie-details"
+  val hmrcFrontendVersion: String = {
     val versionRegex: Regex = raw"hmrc-frontend-([0-9]+\.[0-9]+\.[0-9]+)\.min.js".r
-    val content: String = Source.fromURL(url).mkString
+    val content: String = Source.fromURL(s"$baseUrl/tracking-consent/cookie-settings").mkString
     versionRegex.findFirstMatchIn(content) match {
       case Some(matched) =>
         matched.group(1)
@@ -53,12 +52,12 @@ object TrackingConsentFrontendRequests extends ServicesConfiguration {
   }
 
   val getCookieSettingsPage: HttpRequestBuilder = {
-    val hmrcFrontendVersion = currentHmrcFrontendVersion
+    val version = hmrcFrontendVersion
     http("Load cookie settings page, with assets")
       .get(s"$baseUrl/tracking-consent/cookie-settings?enableTrackingConsent=true")
       .resources(
-        http("hmrc-frontend-css").get(s"$baseUrl/tracking-consent/hmrc-frontend/assets/hmrc-frontend-$hmrcFrontendVersion.min.css"),
-        http("hmrc-frontend-js").get(s"$baseUrl/tracking-consent/hmrc-frontend/assets/hmrc-frontend-$hmrcFrontendVersion.min.js"),
+        http("hmrc-frontend-css").get(s"$baseUrl/tracking-consent/hmrc-frontend/assets/hmrc-frontend-$version.min.css"),
+        http("hmrc-frontend-js").get(s"$baseUrl/tracking-consent/hmrc-frontend/assets/hmrc-frontend-$version.min.js"),
         http("application-css").get(s"$baseUrl/tracking-consent/assets/stylesheets/application.css"),
         http("settings-js").get(s"$baseUrl/tracking-consent/assets/settingsPage.js"),
         http("optimizely-js").get(s"$baseUrl/tracking-consent/assets/optimizely.js"),

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
@@ -40,24 +40,20 @@ object TrackingConsentFrontendRequests extends ServicesConfiguration {
       .check(status.is(200))
   }
 
-  val hmrcFrontendVersion: String = {
+  val getCookieSettingsPage: HttpRequestBuilder = {
     val versionRegex: Regex = raw"hmrc-frontend-([0-9]+\.[0-9]+\.[0-9]+)\.min.js".r
     val content: String = Source.fromURL(s"$baseUrl/tracking-consent/cookie-settings").mkString
-    versionRegex.findFirstMatchIn(content) match {
+    val hmrcFrontendVersion = versionRegex.findFirstMatchIn(content) match {
       case Some(matched) =>
         matched.group(1)
       case None =>
         defaultHmrcFrontendVersion
     }
-  }
-
-  val getCookieSettingsPage: HttpRequestBuilder = {
-    val version = hmrcFrontendVersion
     http("Load cookie settings page, with assets")
       .get(s"$baseUrl/tracking-consent/cookie-settings?enableTrackingConsent=true")
       .resources(
-        http("hmrc-frontend-css").get(s"$baseUrl/tracking-consent/hmrc-frontend/assets/hmrc-frontend-$version.min.css"),
-        http("hmrc-frontend-js").get(s"$baseUrl/tracking-consent/hmrc-frontend/assets/hmrc-frontend-$version.min.js"),
+        http("hmrc-frontend-css").get(s"$baseUrl/tracking-consent/hmrc-frontend/assets/hmrc-frontend-$hmrcFrontendVersion.min.css"),
+        http("hmrc-frontend-js").get(s"$baseUrl/tracking-consent/hmrc-frontend/assets/hmrc-frontend-$hmrcFrontendVersion.min.js"),
         http("application-css").get(s"$baseUrl/tracking-consent/assets/stylesheets/application.css"),
         http("settings-js").get(s"$baseUrl/tracking-consent/assets/settingsPage.js"),
         http("optimizely-js").get(s"$baseUrl/tracking-consent/assets/optimizely.js"),

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendRequests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import io.gatling.http.request.builder.HttpRequestBuilder
 import uk.gov.hmrc.performance.conf.ServicesConfiguration
-
-import java.time.format.DateTimeFormatter
-import java.time.{ZoneOffset, ZonedDateTime}
+import scala.io.Source
+import scala.util.matching.Regex
 
 object TrackingConsentFrontendRequests extends ServicesConfiguration {
 
   private val baseUrl = baseUrlFor("tracking-consent-frontend")
+  private val defaultHmrcFrontendVersion = "5.66.0"
 
   val getTrackingJs: HttpRequestBuilder = {
     http("GET tracking.js")
@@ -40,8 +40,20 @@ object TrackingConsentFrontendRequests extends ServicesConfiguration {
       .check(status.is(200))
   }
 
+  val getLiveHmrcFrontendVersion: String = {
+    val url = "https://staging.tax.service.gov.uk/help/cookie-details"
+    val versionRegex: Regex = raw"hmrc-frontend-([0-9]+\.[0-9]+\.[0-9]+)\.min.js".r
+    val content: String = Source.fromURL(url).mkString
+    versionRegex.findFirstMatchIn(content) match {
+      case Some(matched) =>
+        matched.group(1)
+      case None =>
+        defaultHmrcFrontendVersion
+    }
+  }
+
   val getCookieSettingsPage: HttpRequestBuilder = {
-    val hmrcFrontendVersion = "5.66.0"
+    val hmrcFrontendVersion = getLiveHmrcFrontendVersion
     http("Load cookie settings page, with assets")
       .get(s"$baseUrl/tracking-consent/cookie-settings?enableTrackingConsent=true")
       .resources(

--- a/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendSimulation.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/TrackingConsentFrontendSimulation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Purpose of PR
- Scrape the staging hmrc-frontend version and provide a default for if the staging environment goes down for any reason. 
- Update README.md to describe changes
- Update all Copyright notices to 2024